### PR TITLE
Fix linuxcnc build/install issues for Gentoo

### DIFF
--- a/sci-electronics/linuxcnc/files/Makefile.patch
+++ b/sci-electronics/linuxcnc/files/Makefile.patch
@@ -1,0 +1,11 @@
+--- src/Makefile        2023-04-30 19:02:32.284246088 -0700
++++ src/Makefile        2023-04-30 19:02:42.170992780 -0700
+@@ -733,7 +733,7 @@
+        $(EXE) ../scripts/halreport $(DESTDIR)$(bindir)
+        $(FILE) $(filter ../lib/%.a ../lib/%.so.0,$(TARGETS)) $(DESTDIR)$(libdir)
+        cp --no-dereference $(wildcard ../lib/*.so) $(DESTDIR)$(libdir)
+-       -ldconfig $(DESTDIR)$(libdir)
++       #-ldconfig $(DESTDIR)$(libdir)
+        $(FILE) ../lib/linuxcnc/canterp.so $(DESTDIR)$(libdir)/linuxcnc/
+        $(FILE) $(HEADERS) $(DESTDIR)$(includedir)/linuxcnc/
+        $(TREE) $(NC_FILES) $(DESTDIR)$(ncfilesdir)

--- a/sci-electronics/linuxcnc/linuxcnc-9999-r5.ebuild
+++ b/sci-electronics/linuxcnc/linuxcnc-9999-r5.ebuild
@@ -31,9 +31,9 @@ RDEPEND="
 	$(python_gen_impl_dep 'tk(+)')
 	$(python_gen_cond_dep '
 		>=dev-libs/boost-1.79[python,${PYTHON_USEDEP}]
+		dev-python/pygobject[${PYTHON_USEDEP}]
 		dev-python/pyopengl[${PYTHON_USEDEP}]
 		dev-python/yapps2[${PYTHON_USEDEP}]
-		dev-python/pygobject[${PYTHON_USEDEP}]
 	')
 	dev-lang/tcl
 	dev-lang/tk

--- a/sci-electronics/linuxcnc/linuxcnc-9999-r5.ebuild
+++ b/sci-electronics/linuxcnc/linuxcnc-9999-r5.ebuild
@@ -14,6 +14,10 @@ PYTHON_COMPAT=( python3_{8..11} )
 
 inherit desktop git-r3 python-single-r1 python-utils-r1 xdg-utils
 
+PATCHES=(
+	"${FILESDIR}/Makefile.patch"
+)
+
 DESCRIPTION="An open source CNC machine controller"
 HOMEPAGE="https://www.linuxcnc.org/"
 EGIT_REPO_URI="https://github.com/LinuxCNC/linuxcnc.git"
@@ -29,6 +33,7 @@ RDEPEND="
 		>=dev-libs/boost-1.79[python,${PYTHON_USEDEP}]
 		dev-python/pyopengl[${PYTHON_USEDEP}]
 		dev-python/yapps2[${PYTHON_USEDEP}]
+		dev-python/pygobject[${PYTHON_USEDEP}]
 	')
 	dev-lang/tcl
 	dev-lang/tk


### PR DESCRIPTION
Add a missing dependency on dev-python/pygobject -- build fails without this package installed.
Patch Makefile to not run ldconfig -- the ldconfig command present causes sandbox violations if left in.